### PR TITLE
Use absolute path to Rails root for default options

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+* Use absolute path to Rails root for default options [#3](https://github.com/toy/image_optim_rails/pull/3) [@wjordan](https://github.com/wjordan)
+
 ## v0.3.0 (2017-03-13)
 
 * Add sprockets 4 support [toy/image_optim_rails#2](https://github.com/toy/image_optim_rails/issues/2) [@toy](https://github.com/toy)

--- a/lib/image_optim/railtie.rb
+++ b/lib/image_optim/railtie.rb
@@ -18,7 +18,7 @@ class ImageOptim
             hash[key] = ActiveSupport::OrderedOptions.new
           end
         end
-      app.config.assets.image_optim.merge!(default_options)
+      app.config.assets.image_optim.merge!(default_options(app))
     end
 
     initializer 'image_optim.initializer' do |app|
@@ -42,19 +42,21 @@ class ImageOptim
 
     def options(app)
       if app.config.assets.image_optim == true
-        default_options
+        default_options(app)
       else
-        app.config.assets.image_optim || default_options
+        app.config.assets.image_optim || default_options(app)
       end
     end
 
-    def default_options
+    def default_options(app)
+      config_path = app.config.paths['config'].first
+      tmp_path = app.config.paths['tmp'].first
       {
         :config_paths => [
-          'config/image_optim.yml',
-          "config/image_optim/#{Rails.env}.yml",
+          "#{config_path}/image_optim.yml",
+          "#{config_path}/image_optim/#{Rails.env}.yml",
         ],
-        :cache_dir => 'tmp/cache/image_optim',
+        :cache_dir => "#{tmp_path}/cache/image_optim",
       }
     end
 

--- a/spec/image_optim/railtie_spec.rb
+++ b/spec/image_optim/railtie_spec.rb
@@ -68,12 +68,13 @@ describe 'ImageOptim::Railtie' do
 
     describe 'options' do
       let(:default_options) do
+        root = File.expand_path('../../..', __FILE__)
         {
           :config_paths => [
-            'config/image_optim.yml',
-            'config/image_optim/xxx.yml',
+            "#{root}/config/image_optim.yml",
+            "#{root}/config/image_optim/xxx.yml",
           ],
-          :cache_dir => 'tmp/cache/image_optim',
+          :cache_dir => "#{root}/tmp/cache/image_optim",
         }
       end
 


### PR DESCRIPTION
This PR updates the default options paths from relative paths (`config/image_optim.yml`) to absolute paths based on the Rails root (`/[path/to/rails]/config/image_optim.yml`).

With this PR, the default path to the `image_optim.yml` config file will stay consistent regardless of the current working directory when the Rails environment is loaded.